### PR TITLE
[JENKINS-36184] Update envinject-lib dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.4</version>
-            <scope>test</scope>
+            <scope>optional</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
             <version>1.4</version>
-            <scope>optional</scope>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,7 @@
         <dependency>
             <groupId>org.jenkins-ci.lib</groupId>
             <artifactId>envinject-lib</artifactId>
-            <version>1.23</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.4</version>
-            <optional>true</optional>
+            <version>1.24</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-36184

```
jun 23, 2016 1:24:01 PM hudson.model.Executor finish1
SEVERE: Executor threw an exception
java.lang.NoClassDefFoundError: hudson/matrix/MatrixRun
    at org.jenkinsci.lib.envinject.service.EnvInjectActionRetriever.getEnvInjectAction(EnvInjectActionRetriever.java:25)
    at org.jenkinsci.lib.envinject.service.EnvVarsResolver.getEnVars(EnvVarsResolver.java:56)
    at hudson.plugins.batch_task.BatchRun.run(BatchRun.java:224)
    at hudson.model.ResourceController.execute(ResourceController.java:98)
    at hudson.model.Executor.run(Executor.java:410)
Caused by: java.lang.ClassNotFoundException: hudson.matrix.MatrixRun
    at jenkins.util.AntClassLoader.findClassInComponents(AntClassLoader.java:1376)
    at jenkins.util.AntClassLoader.findClass(AntClassLoader.java:1326)
    at jenkins.util.AntClassLoader.loadClass(AntClassLoader.java:1079)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 5 more
```

I think perhaps the right fix should be on `lib.envinject` but this will not be an immediate solution.

What do you think?

@reviewbybees 
