### PR TITLE
Fix for JENKINS-24581 (rebased PR #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Batch Task Plugin
 =====================
 
-The Batch Task Jenkins plugin adds batch tasks to jenkins jobs that are not regularly executed to projects, such as releases, integration, archiving, etc. In this way, anyone in the project team can execute them in a way that leaves a record.
+The Batch Task Jenkins plugin adds batch tasks to [Jenkins](https://jenkins.io/) jobs. Batch tasks are useful for tasks that are not regularly executed, such as releases, integration, archiving, etc. In this way, anyone in the project team can execute them in a way that leaves a record.
 
 How To Use
 ----------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+
+Batch Task Plugin
+=====================
+
+The Batch Task Jenkins plugin adds batch tasks to jenkins jobs that are not regularly executed to projects, such as releases, integration, archiving, etc. In this way, anyone in the project team can execute them in a way that leaves a record.
+
+How To Use
+----------
+See plugin wiki at https://wiki.jenkins-ci.org/display/JENKINS/Batch+Task+Plugin

--- a/src/main/java/hudson/plugins/batch_task/BatchRun.java
+++ b/src/main/java/hudson/plugins/batch_task/BatchRun.java
@@ -8,6 +8,7 @@ import hudson.tasks.BatchFile;
 import hudson.tasks.CommandInterpreter;
 import hudson.tasks.Shell;
 import hudson.util.Iterators;
+
 import org.jenkinsci.lib.envinject.EnvInjectException;
 import org.jenkinsci.lib.envinject.service.EnvVarsResolver;
 import org.kohsuke.stapler.StaplerRequest;
@@ -119,6 +120,10 @@ public final class BatchRun extends Actionable implements Executable, Comparable
             baseColor = previous.getIconColor();
 
         return baseColor.anime();
+    }
+    
+    public String getBuildStatusIconClassName() {
+      return getIconColor().getIconClassName();
     }
 
     public String getBuildStatusUrl() {


### PR DESCRIPTION
This is a rebased pull request for #1 fixing [JENKINS-24581](https://issues.jenkins-ci.org/browse/JENKINS-24581)

Since many of the original changes of #1 to the plugin have already been redone in the meantime (e.g. upgrading plugin pom), it was easier to rebase than to merge in current master.

These changes update the batch-task plugin so that the build history of the batch tasks correctly display in more recent versions of jenkins, **up until LTS 1.625.3**. Patched version tested with LTS 1.596.3, 1.609.3, and 1.625.3.

**Note:** LTS 1.642.1 introduced a build history pagination and search, which completely hides the batch tasks history items. To correctly support those versions, more work is required.

I would still merge this very minor change to support the Jenkins LTS releases in between. We still use one of those.

The PR also adds a README.md to be displayed on Github.
